### PR TITLE
Fix ssh container config

### DIFF
--- a/car/resources/containers/ssh/config/sshd_config
+++ b/car/resources/containers/ssh/config/sshd_config
@@ -6,6 +6,7 @@ ChallengeResponseAuthentication no
 
 AllowTcpForwarding yes
 PermitTunnel yes
+GatewayPorts clientspecified
 PermitRootLogin no
 
 X11Forwarding no

--- a/car/resources/containers/ssh/docker-compose.yml
+++ b/car/resources/containers/ssh/docker-compose.yml
@@ -9,6 +9,6 @@ services:
     volumes:
       - ${car_ssh_folder}:/home/default
       - ./scripts/start.sh:/scripts/start.sh
-      - ./config/sshd_config:/etc/sshd/sshd_config
+      - ./config/sshd_config:/etc/ssh/sshd_config
     ports:
       - "${car_ssh_port}:22"


### PR DESCRIPTION
The ssh container config (sshd_config) was not correclty mapped inside
the docker_compose.yml. This is now corrected.

Furthermore, the sshd_config option 'GatewayPorts clientspecified' was
added to make remote portforwarding more easy.

This commit resolves issue #1.