### PR TITLE
Fix missing log_folder ajp path

### DIFF
--- a/car/resources/car.toml
+++ b/car/resources/car.toml
@@ -3,6 +3,7 @@
 
   [containers.ajp]
   ajp_folder = "<@:BASE:@>/ajp"
+  log_folder = "<@:BASE:@>/ajp"
   target_port = "8009"
   target_host = "172.17.0.1"
   http_port = "80"


### PR DESCRIPTION
Added the log_folder path for the ajp container to the car.toml file.
This pull request resolves issue #3. 